### PR TITLE
Phase 6a: Error, Loading, Empty States

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,27 +189,76 @@
           </nav>
         </header>
         <div class="max-w-7xl mx-auto px-6 py-12 space-y-12">
-          <section data-tab-panel="dashboard" class="tab-panel">
-            <div class="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
+          <section data-tab-panel="dashboard" class="tab-panel" aria-busy="false">
+            <div
+              id="dashboardSkeleton"
+              class="hidden grid gap-6 animate-pulse lg:grid-cols-2 xl:grid-cols-4"
+              aria-hidden="true"
+            >
+              <div class="rounded-2xl border border-white/10 bg-slate-900/40 p-6">
+                <div class="h-3 w-24 rounded-full bg-white/10"></div>
+                <div class="mt-4 h-10 w-20 rounded-full bg-white/10"></div>
+                <div class="mt-6 space-y-2">
+                  <div class="h-2.5 w-32 rounded-full bg-white/10"></div>
+                  <div class="h-2.5 w-28 rounded-full bg-white/5"></div>
+                </div>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-900/40 p-6">
+                <div class="h-3 w-20 rounded-full bg-white/10"></div>
+                <div class="mt-4 h-10 w-24 rounded-full bg-white/10"></div>
+                <div class="mt-6 space-y-2">
+                  <div class="h-2.5 w-28 rounded-full bg-white/10"></div>
+                  <div class="h-2.5 w-24 rounded-full bg-white/5"></div>
+                </div>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-900/40 p-6">
+                <div class="h-3 w-24 rounded-full bg-white/10"></div>
+                <div class="mt-4 h-10 w-24 rounded-full bg-white/10"></div>
+                <div class="mt-6 space-y-2">
+                  <div class="h-2.5 w-32 rounded-full bg-white/10"></div>
+                  <div class="h-2.5 w-24 rounded-full bg-white/5"></div>
+                </div>
+              </div>
+              <div class="rounded-2xl border border-white/10 bg-slate-900/40 p-6">
+                <div class="h-3 w-16 rounded-full bg-white/10"></div>
+                <div class="mt-4 h-10 w-20 rounded-full bg-white/10"></div>
+                <div class="mt-6 space-y-2">
+                  <div class="h-2.5 w-28 rounded-full bg-white/10"></div>
+                  <div class="h-2.5 w-24 rounded-full bg-white/5"></div>
+                </div>
+              </div>
+            </div>
+            <div id="dashboardMetrics" class="grid gap-6 lg:grid-cols-2 xl:grid-cols-4">
               <div class="rounded-2xl bg-slate-900/70 border border-white/5 p-6">
                 <p class="text-sm text-slate-400">Tasks Today</p>
-                <p class="mt-3 text-3xl font-semibold text-white" id="metric-today">—</p>
+                <p class="mt-3 text-3xl font-semibold text-white" id="metric-today">0</p>
                 <p class="mt-4 text-xs text-slate-500">Coming soon: surfaced from real-time assignments.</p>
               </div>
               <div class="rounded-2xl bg-slate-900/70 border border-white/5 p-6">
                 <p class="text-sm text-slate-400">Completed</p>
-                <p class="mt-3 text-3xl font-semibold text-white" id="metric-complete">—</p>
+                <p class="mt-3 text-3xl font-semibold text-white" id="metric-complete">0</p>
                 <p class="mt-4 text-xs text-slate-500">Completion streaks and throughput analytics arrive in Phase 4.</p>
               </div>
               <div class="rounded-2xl bg-slate-900/70 border border-white/5 p-6">
                 <p class="text-sm text-slate-400">Time Tracked</p>
-                <p class="mt-3 text-3xl font-semibold text-white" id="metric-time">—</p>
+                <p class="mt-3 text-3xl font-semibold text-white" id="metric-time">0m</p>
                 <p class="mt-4 text-xs text-slate-500">Focus mode sessions will sync minutes here.</p>
               </div>
               <div class="rounded-2xl bg-slate-900/70 border border-white/5 p-6">
                 <p class="text-sm text-slate-400">Overdue</p>
-                <p class="mt-3 text-3xl font-semibold text-white" id="metric-overdue">—</p>
+                <p class="mt-3 text-3xl font-semibold text-white" id="metric-overdue">0</p>
                 <p class="mt-4 text-xs text-slate-500">Due date intelligence with nudges ships later.</p>
+              </div>
+            </div>
+            <div
+              id="dashboardEmpty"
+              class="mt-8 hidden flex flex-col items-center gap-4 rounded-3xl border border-dashed border-white/10 bg-slate-900/60 p-8 text-center"
+            >
+              <div class="mx-auto flex max-w-lg flex-col items-center gap-3">
+                <h4 class="text-lg font-semibold text-white">No tasks to show yet</h4>
+                <p class="text-sm text-slate-400">
+                  Spin up a task from the workspace to populate your dashboard metrics and unlock velocity insights.
+                </p>
               </div>
             </div>
             <div class="mt-10 rounded-3xl bg-slate-900/80 border border-white/5 p-8">
@@ -256,20 +305,40 @@
               </div>
               <div
                 id="kanbanLoading"
-                class="hidden items-center gap-3 text-sm text-slate-400 sm:flex"
+                class="hidden"
                 role="status"
                 aria-live="polite"
               >
-                <span class="flex h-2.5 w-2.5 items-center justify-center">
-                  <span class="h-2.5 w-2.5 animate-ping rounded-full bg-aura-primary/70"></span>
-                </span>
-                <span>Syncing tasks&hellip;</span>
+                <span class="sr-only">Loading kanban board&hellip;</span>
+                <div class="flex gap-4 overflow-x-auto pb-6 animate-pulse">
+                  <div class="min-w-[230px] rounded-3xl border border-white/10 bg-slate-950/40 p-5">
+                    <div class="h-3 w-20 rounded-full bg-white/10"></div>
+                    <div class="mt-6 space-y-3">
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                    </div>
+                  </div>
+                  <div class="min-w-[230px] rounded-3xl border border-white/10 bg-slate-950/40 p-5">
+                    <div class="h-3 w-24 rounded-full bg-white/10"></div>
+                    <div class="mt-6 space-y-3">
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                    </div>
+                  </div>
+                  <div class="min-w-[230px] rounded-3xl border border-white/10 bg-slate-950/40 p-5">
+                    <div class="h-3 w-16 rounded-full bg-white/10"></div>
+                    <div class="mt-6 space-y-3">
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                      <div class="h-16 rounded-2xl border border-white/10 bg-slate-900/60"></div>
+                    </div>
+                  </div>
+                </div>
               </div>
               <div
                 id="kanbanEmpty"
-                class="hidden rounded-3xl border border-dashed border-white/10 bg-slate-900/60 p-10 text-center"
+                class="hidden flex flex-col items-center justify-center gap-4 rounded-3xl border border-dashed border-white/10 bg-slate-900/60 p-10 text-center"
               >
-                <div class="mx-auto flex max-w-md flex-col gap-3">
+                <div class="mx-auto flex max-w-md flex-col items-center gap-3">
                   <h4 class="text-lg font-semibold text-white">No tasks yet</h4>
                   <p class="text-sm text-slate-400">
                     When tasks are created they will appear here, ready to be triaged across the workflow.
@@ -393,7 +462,12 @@
                     id="velocityChartEmpty"
                     class="pointer-events-none absolute inset-0 hidden items-center justify-center bg-slate-950/75 px-8 text-center text-sm font-medium text-slate-400 backdrop-blur-sm"
                   >
-                    No completed tasks yet — close work to unlock velocity insights.
+                    <div class="flex flex-col items-center gap-2">
+                      <p class="text-base font-semibold text-white">No data yet</p>
+                      <p class="text-xs font-normal text-slate-400">
+                        Close tasks to unlock completion velocity trends.
+                      </p>
+                    </div>
                   </div>
                 </div>
 
@@ -413,7 +487,12 @@
                     id="categoryChartEmpty"
                     class="pointer-events-none absolute inset-0 hidden items-center justify-center bg-slate-950/75 px-8 text-center text-sm font-medium text-slate-400 backdrop-blur-sm"
                   >
-                    Add duration estimates to your tasks to visualize category distribution.
+                    <div class="flex flex-col items-center gap-2">
+                      <p class="text-base font-semibold text-white">No data yet</p>
+                      <p class="text-xs font-normal text-slate-400">
+                        Add duration estimates to surface category distribution.
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>
@@ -434,7 +513,12 @@
                   id="moodChartEmpty"
                   class="pointer-events-none absolute inset-0 hidden items-center justify-center bg-slate-950/75 px-8 text-center text-sm font-medium text-slate-400 backdrop-blur-sm"
                 >
-                  Log a focus session to begin charting team sentiment.
+                  <div class="flex flex-col items-center gap-2">
+                    <p class="text-base font-semibold text-white">No data yet</p>
+                    <p class="text-xs font-normal text-slate-400">
+                      Log focus sessions to chart evolving mood trends.
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>
@@ -663,6 +747,7 @@
             category: null,
             mood: null,
           },
+          isWorkspaceLoading: false,
         };
         const focusState = {
           durationMinutes: 25,
@@ -677,9 +762,19 @@
           isLoading: false,
           lastUpdated: null,
         };
+        const dragState = {
+          taskId: null,
+          originStatus: null,
+        };
         const elements = {
           analytics: {},
           focus: {},
+          dashboard: {},
+          kanban: {
+            columns: {},
+            lists: {},
+            counts: {},
+          },
         };
 
         const tabs = ['dashboard', 'kanban', 'analytics', 'focus', 'admin'];
@@ -769,7 +864,33 @@
           elements.focus.historyList = document.getElementById('focusHistoryList');
           elements.focus.historyEmpty = document.getElementById('focusHistoryEmpty');
           elements.focus.clearHistoryButton = document.getElementById('focusClearHistoryButton');
-
+          elements.dashboard.section = document.querySelector('[data-tab-panel="dashboard"]');
+          elements.dashboard.skeleton = document.getElementById('dashboardSkeleton');
+          elements.dashboard.metricsContainer = document.getElementById('dashboardMetrics');
+          elements.dashboard.empty = document.getElementById('dashboardEmpty');
+          elements.dashboard.metrics = {
+            today: document.getElementById('metric-today'),
+            complete: document.getElementById('metric-complete'),
+            time: document.getElementById('metric-time'),
+            overdue: document.getElementById('metric-overdue'),
+          };
+          elements.kanban.board = document.getElementById('kanbanBoard');
+          elements.kanban.loading = document.getElementById('kanbanLoading');
+          elements.kanban.empty = document.getElementById('kanbanEmpty');
+          elements.kanban.columns = {};
+          elements.kanban.lists = {};
+          elements.kanban.counts = {};
+          if (elements.kanban.board) {
+            elements.kanban.board.querySelectorAll('[data-kanban-column]').forEach((column) => {
+              const columnId = column.getAttribute('data-kanban-column');
+              if (!columnId) return;
+              elements.kanban.columns[columnId] = column;
+              elements.kanban.lists[columnId] = column.querySelector('[data-kanban-list]');
+              elements.kanban.counts[columnId] = column.querySelector('[data-kanban-count]');
+            });
+          }
+          elements.kanbanBoard = elements.kanban.board;
+          elements.kanbanColumns = elements.kanban.columns;
         }
 
         function enhanceTabButtons() {
@@ -853,6 +974,321 @@
           if (elements.focus.clearHistoryButton) {
             elements.focus.clearHistoryButton.addEventListener('click', clearFocusHistory);
           }
+        }
+
+        function setWorkspaceLoading(isLoading) {
+          state.isWorkspaceLoading = isLoading;
+          if (elements.dashboard.section) {
+            elements.dashboard.section.setAttribute('aria-busy', isLoading ? 'true' : 'false');
+          }
+          if (elements.dashboard.skeleton) {
+            elements.dashboard.skeleton.classList.toggle('hidden', !isLoading);
+          }
+          if (elements.dashboard.metricsContainer) {
+            elements.dashboard.metricsContainer.classList.toggle('hidden', isLoading);
+          }
+          if (isLoading && elements.dashboard.empty) {
+            elements.dashboard.empty.classList.add('hidden');
+          }
+          if (elements.kanban.loading) {
+            elements.kanban.loading.classList.toggle('hidden', !isLoading);
+          }
+          if (elements.kanban.board) {
+            elements.kanban.board.classList.toggle('hidden', isLoading);
+          }
+          if (isLoading && elements.kanban.empty) {
+            elements.kanban.empty.classList.add('hidden');
+          }
+        }
+
+        function updateDashboardMetrics() {
+          const metrics = elements.dashboard.metrics || {};
+          if (!metrics.today || !metrics.complete || !metrics.time || !metrics.overdue) {
+            return;
+          }
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+          let tasksToday = 0;
+          let completed = 0;
+          let overdue = 0;
+          let trackedMinutes = 0;
+          const now = new Date();
+          tasks.forEach((task) => {
+            if (!task) return;
+            const status = normalizeStatus(task.Status);
+            if (status === 'Completed') {
+              completed += 1;
+            }
+            const minutes = Number(task.DurationMins || task.Duration || 0);
+            if (Number.isFinite(minutes) && minutes > 0) {
+              trackedMinutes += minutes;
+            }
+            const dueDate = parseDateValue(task.DueAt || task.DueDate || task.DueOn || task.Due);
+            if (dueDate) {
+              const dueDay = new Date(dueDate);
+              dueDay.setHours(0, 0, 0, 0);
+              if (isSameDay(dueDay, today)) {
+                tasksToday += 1;
+              }
+              if (dueDate < now && status !== 'Completed') {
+                overdue += 1;
+              }
+            } else {
+              const created = parseDateValue(task.Timestamp || task.CreatedAt || task.CreatedOn);
+              if (created) {
+                const createdDay = new Date(created);
+                createdDay.setHours(0, 0, 0, 0);
+                if (isSameDay(createdDay, today)) {
+                  tasksToday += 1;
+                }
+              }
+            }
+          });
+          metrics.today.textContent = String(tasksToday);
+          metrics.complete.textContent = String(completed);
+          metrics.time.textContent = trackedMinutes ? formatMinutes(trackedMinutes) : '0m';
+          metrics.overdue.textContent = String(overdue);
+          const shouldShowEmpty = !tasks.length && !state.isWorkspaceLoading;
+          toggleEmptyState(elements.dashboard.empty, shouldShowEmpty, 'flex');
+        }
+
+        function renderKanbanBoard() {
+          const lists = elements.kanban.lists || {};
+          const counts = elements.kanban.counts || {};
+          const board = elements.kanban.board;
+          if (!board) {
+            return;
+          }
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
+          const grouped = new Map();
+          tasks.forEach((task) => {
+            if (!task) return;
+            const statusId = normalizeStatus(task.Status);
+            if (!grouped.has(statusId)) {
+              grouped.set(statusId, []);
+            }
+            grouped.get(statusId).push(task);
+          });
+          KANBAN_STATUSES.forEach((status) => {
+            const list = lists[status.id];
+            if (list) {
+              list.innerHTML = '';
+            }
+            const columnTasks = grouped.get(status.id) || [];
+            if (list) {
+              if (!columnTasks.length) {
+                list.appendChild(createKanbanPlaceholderCard());
+              } else {
+                columnTasks
+                  .sort((a, b) => {
+                    const aDate = parseDateValue(a.UpdatedAt || a.Timestamp);
+                    const bDate = parseDateValue(b.UpdatedAt || b.Timestamp);
+                    const aTime = aDate ? aDate.getTime() : 0;
+                    const bTime = bDate ? bDate.getTime() : 0;
+                    return bTime - aTime;
+                  })
+                  .forEach((task) => {
+                    list.appendChild(createKanbanCard(task, status.id));
+                  });
+              }
+            }
+            const badge = counts[status.id];
+            if (badge) {
+              badge.textContent = String(columnTasks.length);
+            }
+          });
+          const shouldShowEmpty = !tasks.length && !state.isWorkspaceLoading;
+          toggleEmptyState(elements.kanban.empty, shouldShowEmpty, 'flex');
+          if (!state.isWorkspaceLoading) {
+            board.classList.remove('hidden');
+          }
+        }
+
+        function createKanbanCard(task, statusId) {
+          const card = document.createElement('article');
+          card.className = 'group rounded-2xl border border-white/10 bg-slate-950/70 p-4 text-sm text-slate-200 shadow-sm transition hover:border-white/20';
+          card.draggable = true;
+          card.setAttribute('data-task-id', task.TaskID);
+          card.setAttribute('role', 'listitem');
+          card.setAttribute('aria-grabbed', 'false');
+          const title = escapeHtml(task.Name || task.TaskID || 'Untitled task');
+          const dueLabel = formatDueLabel(task.DueAt || task.DueDate || task.DueOn || task.Due);
+          const metaParts = [];
+          if (task.Assignee) {
+            const assignee = formatAssigneeLabel(task.Assignee);
+            if (assignee) {
+              metaParts.push(assignee);
+            }
+          }
+          const minutes = Number(task.DurationMins || task.Duration || 0);
+          if (Number.isFinite(minutes) && minutes > 0) {
+            metaParts.push(formatMinutes(minutes));
+          }
+          if (task.Priority) {
+            metaParts.push(String(task.Priority));
+          }
+          const content = [];
+          content.push(`
+            <div class="flex items-start justify-between gap-3">
+              <p class="font-medium text-slate-100">${title}</p>
+              ${dueLabel ? `<span class="rounded-full bg-white/10 px-2 py-0.5 text-xs font-medium text-slate-300">${escapeHtml(dueLabel)}</span>` : ''}
+            </div>
+          `);
+          if (task.Category) {
+            content.push(`<p class="mt-2 text-xs uppercase tracking-[0.2em] text-slate-500">${escapeHtml(task.Category)}</p>`);
+          }
+          if (metaParts.length) {
+            content.push(`<p class="mt-2 text-xs text-slate-400">${escapeHtml(metaParts.join(' • '))}</p>`);
+          }
+          card.innerHTML = content.join('');
+          card.addEventListener('dragstart', (event) => handleKanbanDragStart(event, task.TaskID, statusId));
+          card.addEventListener('dragend', handleKanbanDragEnd);
+          return card;
+        }
+
+        function createKanbanPlaceholderCard() {
+          const placeholder = document.createElement('div');
+          placeholder.className = 'flex flex-col gap-3 rounded-2xl border border-dashed border-white/10 bg-slate-950/40 p-4 animate-pulse';
+          placeholder.setAttribute('aria-hidden', 'true');
+          placeholder.innerHTML = `
+            <div class="h-3 w-3/4 rounded-full bg-white/10"></div>
+            <div class="h-3 w-1/2 rounded-full bg-white/5"></div>
+            <div class="h-8 rounded-xl bg-white/5"></div>
+          `;
+          return placeholder;
+        }
+
+        function handleKanbanDragStart(event, taskId, statusId) {
+          dragState.taskId = taskId;
+          dragState.originStatus = statusId;
+          if (event.dataTransfer) {
+            event.dataTransfer.effectAllowed = 'move';
+            event.dataTransfer.setData('text/plain', taskId);
+          }
+          if (event.currentTarget) {
+            event.currentTarget.classList.add('opacity-60');
+            event.currentTarget.setAttribute('aria-grabbed', 'true');
+          }
+        }
+
+        function handleKanbanDragEnd(event) {
+          if (event && event.currentTarget) {
+            event.currentTarget.classList.remove('opacity-60');
+            event.currentTarget.setAttribute('aria-grabbed', 'false');
+          }
+          dragState.taskId = null;
+          dragState.originStatus = null;
+          clearKanbanHighlights();
+        }
+
+        function handleKanbanDragEnter(event, statusId) {
+          if (!dragState.taskId) {
+            return;
+          }
+          event.preventDefault();
+          highlightKanbanColumn(statusId, true);
+        }
+
+        function handleKanbanDragOver(event, statusId) {
+          if (!dragState.taskId) {
+            return;
+          }
+          event.preventDefault();
+          highlightKanbanColumn(statusId, true);
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+          }
+        }
+
+        function handleKanbanDragLeave(event, statusId) {
+          if (!dragState.taskId) {
+            return;
+          }
+          if (event.relatedTarget && event.currentTarget && event.currentTarget.contains(event.relatedTarget)) {
+            return;
+          }
+          highlightKanbanColumn(statusId, false);
+        }
+
+        async function handleKanbanDrop(event, statusId) {
+          if (!dragState.taskId) {
+            return;
+          }
+          event.preventDefault();
+          const taskId = dragState.taskId;
+          dragState.taskId = null;
+          dragState.originStatus = null;
+          highlightKanbanColumn(statusId, false);
+          clearKanbanHighlights();
+          await moveTaskToStatus(taskId, statusId);
+        }
+
+        async function moveTaskToStatus(taskId, nextStatus) {
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
+          const task = tasks.find((entry) => entry && entry.TaskID === taskId);
+          if (!task) {
+            renderKanbanBoard();
+            return;
+          }
+          const previousStatus = normalizeStatus(task.Status);
+          const targetStatus = normalizeStatus(nextStatus);
+          if (previousStatus === targetStatus) {
+            renderKanbanBoard();
+            return;
+          }
+          if (!state.token) {
+            showToast('Sign in to update tasks.', 'error');
+            renderKanbanBoard();
+            return;
+          }
+          task.Status = targetStatus;
+          renderKanbanBoard();
+          updateDashboardMetrics();
+          try {
+            const updated = await server.updateTask(state.token, taskId, { Status: targetStatus });
+            if (updated && typeof updated === 'object') {
+              Object.assign(task, updated);
+            }
+            const taskName = escapeHtml(task.Name || task.TaskID || taskId);
+            showToast(`Moved “${taskName}” to ${escapeHtml(targetStatus)}.`, 'success');
+          } catch (err) {
+            task.Status = previousStatus;
+            renderKanbanBoard();
+            updateDashboardMetrics();
+            showToast(err && err.message ? err.message : 'Unable to update task status.', 'error');
+          }
+        }
+
+        function highlightKanbanColumn(statusId, shouldHighlight) {
+          const column = elements.kanban.columns ? elements.kanban.columns[statusId] : null;
+          if (!column) {
+            return;
+          }
+          COLUMN_HIGHLIGHT_CLASSES.forEach((cls) => {
+            column.classList.toggle(cls, shouldHighlight);
+          });
+        }
+
+        function clearKanbanHighlights() {
+          Object.keys(elements.kanban.columns || {}).forEach((key) => {
+            highlightKanbanColumn(key, false);
+          });
+        }
+
+        function resetKanbanState() {
+          Object.values(elements.kanban.lists || {}).forEach((list) => {
+            if (list) {
+              list.innerHTML = '';
+            }
+          });
+          Object.values(elements.kanban.counts || {}).forEach((badge) => {
+            if (badge) {
+              badge.textContent = '0';
+            }
+          });
+          clearKanbanHighlights();
+          renderKanbanBoard();
         }
 
         async function handleLoginSubmit(event) {
@@ -963,6 +1399,7 @@
             elements.roleBadge.textContent = isAuthenticated && state.user.Role ? state.user.Role : '';
           }
           renderKanbanBoard();
+          updateDashboardMetrics();
           setActiveTab(state.activeTab);
         }
 
@@ -1027,6 +1464,7 @@
             return;
           }
           analyticsState.isLoading = true;
+          setWorkspaceLoading(true);
           if (elements.analytics.refreshButton && !silent) {
             setButtonLoading(elements.analytics.refreshButton, true);
           }
@@ -1050,6 +1488,9 @@
             if (elements.analytics.refreshButton && !silent) {
               setButtonLoading(elements.analytics.refreshButton, false);
             }
+            setWorkspaceLoading(false);
+            updateDashboardMetrics();
+            renderKanbanBoard();
           }
         }
 
@@ -1668,12 +2109,68 @@
           updateFocusStatus('ready');
           updateFocusControls();
           updateFocusHistoryUi();
+          updateDashboardMetrics();
+          renderKanbanBoard();
+          setWorkspaceLoading(false);
         }
 
-        function toggleEmptyState(element, shouldShow) {
+        function toggleEmptyState(element, shouldShow, displayClass = 'flex') {
           if (!element) return;
           element.classList.toggle('hidden', !shouldShow);
-          element.classList.toggle('flex', shouldShow);
+          if (displayClass) {
+            element.classList.toggle(displayClass, shouldShow);
+          }
+        }
+
+        function normalizeStatus(status) {
+          const label = String(status || '').trim();
+          if (!label) {
+            return 'Planned';
+          }
+          if (KANBAN_STATUSES.some((entry) => entry.id === label)) {
+            return label;
+          }
+          const lower = label.toLowerCase();
+          const match = KANBAN_STATUSES.find((entry) => entry.id.toLowerCase() === lower);
+          return match ? match.id : 'Planned';
+        }
+
+        function parseDateValue(value) {
+          if (!value) {
+            return null;
+          }
+          if (value instanceof Date) {
+            return Number.isNaN(value.getTime()) ? null : value;
+          }
+          const parsed = new Date(value);
+          return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+
+        function isSameDay(a, b) {
+          if (!a || !b) {
+            return false;
+          }
+          return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth() && a.getDate() === b.getDate();
+        }
+
+        function formatAssigneeLabel(value) {
+          if (!value) {
+            return '';
+          }
+          const normalized = String(value).trim();
+          if (!normalized) {
+            return '';
+          }
+          const [name] = normalized.split('@');
+          return name || normalized;
+        }
+
+        function formatDueLabel(value) {
+          const date = parseDateValue(value);
+          if (!date) {
+            return '';
+          }
+          return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
         }
 
         function formatDateKey(value) {


### PR DESCRIPTION
## Summary
* Added dashboard skeleton loader, default metrics, and an empty-state prompt so users understand the dashboard when no tasks exist.
* Revamped Kanban loading and empty behaviour with skeletons, placeholder cards, and drag-and-drop updates that show toast errors when API calls fail while keeping metrics in sync.
* Standardized analytics "No data yet" overlays for velocity, category, and mood charts.

## Testing
* ⚠️ Not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68cab0a17730832f88d72aa1421a51f4