### PR TITLE
Phase 5b: Reports Export

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -569,6 +569,323 @@ function listTasks(token, filters) {
   });
 }
 
+function exportTasksCsv(token, filters) {
+  return handleApi_(function () {
+    var session = requireSession_(token);
+    ensurePermission_(session, 'reports:generate');
+
+    var usersMap = loadUsersMap_();
+    var normalizedFilters = normalizeTaskFilters_(filters, session);
+
+    var sheet = ensureSheet_(SHEET_NAMES.TASKS, SHEET_HEADERS[SHEET_NAMES.TASKS]);
+    var rows = sheetObjects_(sheet, SHEET_HEADERS[SHEET_NAMES.TASKS]);
+
+    var exportRecords = [];
+    for (var i = 0; i < rows.length; i++) {
+      var record = rows[i];
+      if (!canViewTask_(session, record, usersMap)) {
+        continue;
+      }
+      if (!taskMatchesFilters_(record, normalizedFilters)) {
+        continue;
+      }
+      exportRecords.push(sanitizeTask_(record));
+    }
+
+    exportRecords.sort(function (a, b) {
+      var aKey = (a && a.UpdatedAt) || (a && a.Timestamp) || '';
+      var bKey = (b && b.UpdatedAt) || (b && b.Timestamp) || '';
+      if (aKey === bKey) {
+        return 0;
+      }
+      return aKey < bKey ? 1 : -1;
+    });
+
+    var headers = SHEET_HEADERS[SHEET_NAMES.TASKS];
+    var csvLines = [];
+    var headerValues = [];
+    for (var h = 0; h < headers.length; h++) {
+      headerValues.push(escapeCsvValue_(headers[h]));
+    }
+    csvLines.push(headerValues.join(','));
+
+    for (var j = 0; j < exportRecords.length; j++) {
+      var rowValues = [];
+      var recordObject = exportRecords[j];
+      for (var k = 0; k < headers.length; k++) {
+        var key = headers[k];
+        var rawValue = recordObject[key];
+        if (key === 'Labels') {
+          rawValue = toCsvString_(rawValue);
+        }
+        if (rawValue === undefined || rawValue === null) {
+          rawValue = '';
+        } else if (Object.prototype.toString.call(rawValue) === '[object Date]') {
+          rawValue = rawValue.toISOString();
+        } else if (Array.isArray(rawValue)) {
+          rawValue = toCsvString_(rawValue);
+        }
+        rowValues.push(escapeCsvValue_(rawValue));
+      }
+      csvLines.push(rowValues.join(','));
+    }
+
+    var timezone = Session.getScriptTimeZone() || 'Etc/UTC';
+    var timestamp = Utilities.formatDate(new Date(), timezone, 'yyyyMMdd_HHmmss');
+    var filename = 'aura-flow-tasks-' + timestamp + '.csv';
+    var csvContent = '\ufeff' + csvLines.join('\r\n');
+
+    logActivity_(session, 'report.export.csv', 'Task', '', {
+      count: exportRecords.length,
+      filters: normalizedFilters
+    });
+
+    return {
+      filename: filename,
+      mimeType: 'text/csv',
+      content: csvContent
+    };
+  });
+}
+
+function generatePdfReport(token, filters) {
+  return handleApi_(function () {
+    var session = requireSession_(token);
+    ensurePermission_(session, 'reports:generate');
+
+    var usersMap = loadUsersMap_();
+    var normalizedFilters = normalizeTaskFilters_(filters, session);
+
+    var sheet = ensureSheet_(SHEET_NAMES.TASKS, SHEET_HEADERS[SHEET_NAMES.TASKS]);
+    var rows = sheetObjects_(sheet, SHEET_HEADERS[SHEET_NAMES.TASKS]);
+
+    var tasks = [];
+    var taskIdMap = {};
+    for (var i = 0; i < rows.length; i++) {
+      var record = rows[i];
+      if (!canViewTask_(session, record, usersMap)) {
+        continue;
+      }
+      if (!taskMatchesFilters_(record, normalizedFilters)) {
+        continue;
+      }
+      var sanitized = sanitizeTask_(record);
+      tasks.push(sanitized);
+      if (sanitized && sanitized.TaskID) {
+        taskIdMap[sanitized.TaskID] = true;
+      }
+    }
+
+    tasks.sort(function (a, b) {
+      var aKey = (a && a.UpdatedAt) || (a && a.Timestamp) || '';
+      var bKey = (b && b.UpdatedAt) || (b && b.Timestamp) || '';
+      if (aKey === bKey) {
+        return 0;
+      }
+      return aKey < bKey ? 1 : -1;
+    });
+
+    var statusCounts = {};
+    var totalDurationMins = 0;
+    for (var j = 0; j < tasks.length; j++) {
+      var task = tasks[j];
+      var status = (task && task.Status) || 'Planned';
+      if (!statusCounts.hasOwnProperty(status)) {
+        statusCounts[status] = 0;
+      }
+      statusCounts[status]++;
+      var durationNumber = Number(task && task.DurationMins);
+      if (!isNaN(durationNumber)) {
+        totalDurationMins += Math.max(0, durationNumber);
+      }
+    }
+
+    var timezone = Session.getScriptTimeZone() || 'Etc/UTC';
+    var generatedAtDate = new Date();
+    var generatedAt = Utilities.formatDate(generatedAtDate, timezone, 'yyyy-MM-dd HH:mm:ss');
+    var timestamp = Utilities.formatDate(generatedAtDate, timezone, 'yyyyMMdd_HHmmss');
+
+    var filterSummaries = [];
+    if (normalizedFilters.statuses && normalizedFilters.statuses.length) {
+      filterSummaries.push('Statuses: ' + normalizedFilters.statuses.join(', '));
+    }
+    if (normalizedFilters.assignee) {
+      filterSummaries.push('Assignee: ' + normalizedFilters.assignee);
+    }
+    if (normalizedFilters.dueAfter) {
+      filterSummaries.push('Due After: ' + Utilities.formatDate(normalizedFilters.dueAfter, timezone, 'yyyy-MM-dd'));
+    }
+    if (normalizedFilters.dueBefore) {
+      filterSummaries.push('Due Before: ' + Utilities.formatDate(normalizedFilters.dueBefore, timezone, 'yyyy-MM-dd'));
+    }
+
+    var summaryMetrics = [
+      { label: 'Total Tasks', value: String(tasks.length) },
+      { label: 'Completed', value: String(statusCounts['Completed'] || 0) },
+      { label: 'In-Progress', value: String(statusCounts['In-Progress'] || 0) },
+      { label: 'Total Est. Time', value: formatDurationLabel_(totalDurationMins) }
+    ];
+
+    var moodSheet = ensureSheet_(SHEET_NAMES.MOODS, SHEET_HEADERS[SHEET_NAMES.MOODS]);
+    var moodRows = sheetObjects_(moodSheet, SHEET_HEADERS[SHEET_NAMES.MOODS]);
+    var scope = resolveMoodScope_(session, usersMap);
+    var moodCounts = {};
+    var moodTotal = 0;
+    var requireTaskMatch = Object.keys(taskIdMap).length > 0;
+    for (var m = 0; m < moodRows.length; m++) {
+      var moodRecord = sanitizeMood_(moodRows[m]);
+      if (!moodRecord) {
+        continue;
+      }
+      if (!scope[moodRecord.Email]) {
+        continue;
+      }
+      if (requireTaskMatch) {
+        if (!moodRecord.TaskID || !taskIdMap[moodRecord.TaskID]) {
+          continue;
+        }
+      }
+      var moodLabel = moodRecord.Mood ? String(moodRecord.Mood).trim() : '';
+      if (!moodLabel) {
+        moodLabel = 'Unspecified';
+      }
+      var displayMood = moodLabel.charAt(0).toUpperCase() + moodLabel.slice(1);
+      if (!moodCounts.hasOwnProperty(displayMood)) {
+        moodCounts[displayMood] = 0;
+      }
+      moodCounts[displayMood]++;
+      moodTotal++;
+    }
+
+    summaryMetrics.push({ label: 'Mood Entries', value: String(moodTotal) });
+
+    var statusRowsHtml = '';
+    for (var s = 0; s < TASK_STATUSES.length; s++) {
+      var statusKey = TASK_STATUSES[s];
+      var statusCount = statusCounts[statusKey] || 0;
+      statusRowsHtml +=
+        '<tr><td>' +
+        escapeHtml_(statusKey) +
+        '</td><td>' +
+        escapeHtml_(String(statusCount)) +
+        '</td></tr>';
+      if (statusCounts.hasOwnProperty(statusKey)) {
+        delete statusCounts[statusKey];
+      }
+    }
+    for (var remainingStatus in statusCounts) {
+      if (!statusCounts.hasOwnProperty(remainingStatus)) {
+        continue;
+      }
+      statusRowsHtml +=
+        '<tr><td>' +
+        escapeHtml_(remainingStatus) +
+        '</td><td>' +
+        escapeHtml_(String(statusCounts[remainingStatus])) +
+        '</td></tr>';
+    }
+    if (!statusRowsHtml) {
+      statusRowsHtml = '<tr><td colspan="2">No tasks available for the selected filters.</td></tr>';
+    }
+
+    var moodRowsHtml = '';
+    for (var moodName in moodCounts) {
+      if (!moodCounts.hasOwnProperty(moodName)) {
+        continue;
+      }
+      moodRowsHtml +=
+        '<tr><td>' +
+        escapeHtml_(moodName) +
+        '</td><td>' +
+        escapeHtml_(String(moodCounts[moodName])) +
+        '</td></tr>';
+    }
+    if (!moodRowsHtml) {
+      moodRowsHtml = '<tr><td colspan="2">No mood logs associated with the selected tasks.</td></tr>';
+    }
+
+    var summaryHtml = '';
+    for (var q = 0; q < summaryMetrics.length; q++) {
+      var metric = summaryMetrics[q];
+      summaryHtml +=
+        '<div class="summary-item"><strong>' +
+        escapeHtml_(metric.value) +
+        '</strong><span>' +
+        escapeHtml_(metric.label) +
+        '</span></div>';
+    }
+
+    var filtersHtml = '';
+    if (filterSummaries.length) {
+      filtersHtml = '<ul>';
+      for (var f = 0; f < filterSummaries.length; f++) {
+        filtersHtml += '<li>' + escapeHtml_(filterSummaries[f]) + '</li>';
+      }
+      filtersHtml += '</ul>';
+    } else {
+      filtersHtml = '<p>None — full task inventory included.</p>';
+    }
+
+    var generatedFor = '';
+    if (session && session.user && session.user.Email) {
+      generatedFor = session.user.Email;
+    } else {
+      generatedFor = getSessionEmail_(session) || '';
+    }
+
+    var html =
+      '<!DOCTYPE html>' +
+      '<html><head><meta charset="UTF-8" />' +
+      '<style>' +
+      'body{font-family:"Helvetica Neue",Helvetica,Arial,sans-serif;color:#0f172a;margin:36px;}' +
+      'h1{font-size:24px;margin:0 0 4px 0;color:#111827;}' +
+      'h2{font-size:18px;margin:24px 0 8px 0;color:#111827;}' +
+      'h3{font-size:16px;margin:18px 0 6px 0;color:#111827;}' +
+      'p,li,span{font-size:12px;line-height:1.6;color:#334155;}' +
+      'ul{padding-left:18px;margin:8px 0;}' +
+      'table{width:100%;border-collapse:collapse;margin-top:12px;font-size:12px;}' +
+      'th,td{border:1px solid #d1d5db;padding:8px 10px;text-align:left;}' +
+      'th{background:#f3f4f6;font-weight:600;color:#1f2937;}' +
+      '.summary{display:flex;flex-wrap:wrap;gap:12px;margin-top:12px;}' +
+      '.summary-item{flex:1 1 160px;border:1px solid #e2e8f0;border-radius:8px;padding:12px 14px;background:#f8fafc;}' +
+      '.summary-item strong{display:block;font-size:18px;color:#111827;margin-bottom:4px;}' +
+      '.meta{margin:0;color:#64748b;}' +
+      '.footer{margin-top:32px;font-size:11px;color:#64748b;}' +
+      '</style></head><body>' +
+      '<h1>Aura Flow V2 — Task &amp; Mood Report</h1>' +
+      '<p class="meta">Generated for ' + escapeHtml_(generatedFor || 'N/A') + '</p>' +
+      '<p class="meta">Generated at ' + escapeHtml_(generatedAt) + ' (' + escapeHtml_(timezone) + ')</p>' +
+      '<div class="summary">' + summaryHtml + '</div>' +
+      '<div class="section"><h2>Applied Filters</h2>' + filtersHtml + '</div>' +
+      '<div class="section"><h2>Task Status Distribution</h2><table><thead><tr><th>Status</th><th>Count</th></tr></thead><tbody>' +
+      statusRowsHtml +
+      '</tbody></table></div>' +
+      '<div class="section"><h2>Mood Counts</h2><table><thead><tr><th>Mood</th><th>Entries</th></tr></thead><tbody>' +
+      moodRowsHtml +
+      '</tbody></table></div>' +
+      '<p class="footer">Aura Flow V2 automatically aggregates workspace data from Tasks and Mood services. Export generated on ' +
+      escapeHtml_(generatedAt) +
+      '.</p>' +
+      '</body></html>';
+
+    var blob = Utilities.newBlob(html, 'text/html').getAs('application/pdf');
+    var filename = 'aura-flow-report-' + timestamp + '.pdf';
+    blob.setName(filename);
+    var base64 = Utilities.base64Encode(blob.getBytes());
+
+    logActivity_(session, 'report.export.pdf', 'Task', '', {
+      count: tasks.length,
+      filters: normalizedFilters
+    });
+
+    return {
+      filename: filename,
+      mimeType: 'application/pdf',
+      base64: base64
+    };
+  });
+}
+
 function deleteTask(token, taskId) {
   return handleApi_(function () {
     var session = requireSession_(token);
@@ -1705,6 +2022,17 @@ function toCsvString_(value) {
   return String(value);
 }
 
+function escapeCsvValue_(value) {
+  if (value === undefined || value === null) {
+    return '""';
+  }
+  var stringValue = String(value);
+  if (stringValue.indexOf('"') !== -1 || stringValue.indexOf(',') !== -1 || /[\r\n]/.test(stringValue)) {
+    return '"' + stringValue.replace(/"/g, '""') + '"';
+  }
+  return stringValue;
+}
+
 function parseLabels_(value) {
   if (value === undefined || value === null || value === '') {
     return [];
@@ -1747,6 +2075,22 @@ function normalizeDuration_(value, fallback) {
     return 0;
   }
   return Math.round(num * 100) / 100;
+}
+
+function formatDurationLabel_(minutes) {
+  var total = Math.round(Number(minutes) || 0);
+  if (!total) {
+    return '0m';
+  }
+  var hours = Math.floor(total / 60);
+  var remainder = total % 60;
+  if (hours && remainder) {
+    return hours + 'h ' + remainder + 'm';
+  }
+  if (hours) {
+    return hours + 'h';
+  }
+  return remainder + 'm';
 }
 
 function normalizeTaskCategory_(value) {
@@ -1821,6 +2165,18 @@ function sanitizeMood_(record) {
     Note: record.Note || '',
     At: record.At || ''
   };
+}
+
+function escapeHtml_(value) {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
 }
 
 function getTaskById_(taskId) {

--- a/index.html
+++ b/index.html
@@ -437,6 +437,37 @@
                   Log a focus session to begin charting team sentiment.
                 </div>
               </div>
+
+              <div class="rounded-3xl border border-white/5 bg-slate-900/70 p-6">
+                <div class="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <div>
+                    <p class="text-xs uppercase tracking-[0.3em] text-slate-500">Reports</p>
+                    <h4 class="mt-1 text-lg font-semibold text-white">Exports</h4>
+                    <p class="mt-3 text-sm text-slate-400">
+                      Download your filtered task grid or a leadership-ready PDF snapshot.
+                    </p>
+                  </div>
+                  <div class="flex flex-wrap items-center gap-3">
+                    <button
+                      id="reportExportCsv"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-4 py-2 text-sm font-medium text-slate-100 transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aura-primary"
+                    >
+                      <span data-role="spinner" class="hidden h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-transparent"></span>
+                      <span data-role="label">Export CSV</span>
+                    </button>
+                    <button
+                      id="reportExportPdf"
+                      type="button"
+                      class="inline-flex items-center gap-2 rounded-xl bg-aura-primary/90 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-aura-primary/30 transition hover:bg-aura-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aura-primary"
+                    >
+                      <span data-role="spinner" class="hidden h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-transparent"></span>
+                      <span data-role="label">Export PDF</span>
+                    </button>
+                  </div>
+                </div>
+                <p class="mt-4 text-xs text-slate-500">Reports respect task visibility and any filters in play.</p>
+              </div>
             </div>
           </section>
 
@@ -753,6 +784,8 @@
           elements.analytics.moodCanvas = document.getElementById('moodTrendChart');
           elements.analytics.moodEmpty = document.getElementById('moodChartEmpty');
           elements.analytics.moodMetric = document.getElementById('moodMetric');
+          elements.analytics.exportCsvButton = document.getElementById('reportExportCsv');
+          elements.analytics.exportPdfButton = document.getElementById('reportExportPdf');
           elements.focus.statusBadge = document.getElementById('focusStatusBadge');
           if (elements.focus.statusBadge) {
             elements.focus.statusDot = elements.focus.statusBadge.querySelector('[data-role="focus-status-dot"]');
@@ -832,6 +865,12 @@
           if (elements.analytics.refreshButton) {
             elements.analytics.refreshButton.addEventListener('click', () => refreshWorkspaceData({ silent: false }));
           }
+          if (elements.analytics.exportCsvButton) {
+            elements.analytics.exportCsvButton.addEventListener('click', handleExportCsvClick);
+          }
+          if (elements.analytics.exportPdfButton) {
+            elements.analytics.exportPdfButton.addEventListener('click', handleExportPdfClick);
+          }
           if (elements.focus.startButton) {
             elements.focus.startButton.addEventListener('click', startFocusTimer);
           }
@@ -893,6 +932,66 @@
             }
           }
           showToast('You are signed out.', 'success');
+        }
+
+        function buildReportFilters() {
+          return {};
+        }
+
+        async function handleExportCsvClick() {
+          if (!state.token) {
+            showToast('Sign in to export reports.', 'error');
+            return;
+          }
+          const button = elements.analytics.exportCsvButton;
+          setButtonLoading(button, true);
+          try {
+            const filters = buildReportFilters();
+            const result = await server.exportTasksCsv(state.token, filters);
+            const content = result && typeof result === 'object' && 'content' in result ? result.content : result;
+            if (!content) {
+              throw new Error('No CSV data was generated.');
+            }
+            const filename = (result && result.filename) || `aura-flow-tasks-${Date.now()}.csv`;
+            const mimeType = (result && result.mimeType) || 'text/csv';
+            const blob = new Blob([content], { type: `${mimeType};charset=utf-8` });
+            downloadBlob(blob, filename);
+            showToast('Tasks CSV export ready.', 'success');
+          } catch (err) {
+            console.error('CSV export failed:', err);
+            showToast(err && err.message ? err.message : 'Failed to export CSV.', 'error');
+          } finally {
+            setButtonLoading(button, false);
+          }
+        }
+
+        async function handleExportPdfClick() {
+          if (!state.token) {
+            showToast('Sign in to export reports.', 'error');
+            return;
+          }
+          const button = elements.analytics.exportPdfButton;
+          setButtonLoading(button, true);
+          try {
+            const filters = buildReportFilters();
+            const result = await server.generatePdfReport(state.token, filters);
+            if (!result || !result.base64) {
+              throw new Error('No PDF data was generated.');
+            }
+            const filename = result.filename || `aura-flow-report-${Date.now()}.pdf`;
+            const mimeType = result.mimeType || 'application/pdf';
+            const blob = base64ToBlob(result.base64, mimeType);
+            if (!blob || !blob.size) {
+              throw new Error('Unable to prepare PDF download.');
+            }
+            downloadBlob(blob, filename);
+            showToast('PDF report generated.', 'success');
+          } catch (err) {
+            console.error('PDF export failed:', err);
+            showToast(err && err.message ? err.message : 'Failed to export PDF.', 'error');
+          } finally {
+            setButtonLoading(button, false);
+          }
         }
 
         function setButtonLoading(button, isLoading) {
@@ -1701,6 +1800,39 @@
           if (hours && mins) return `${hours}h ${mins}m`;
           if (hours) return `${hours}h`;
           return `${mins}m`;
+        }
+
+        function downloadBlob(blob, filename) {
+          if (!blob) {
+            throw new Error('Nothing to download.');
+          }
+          if (typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+            throw new Error('Download not supported in this environment.');
+          }
+          const url = URL.createObjectURL(blob);
+          const anchor = document.createElement('a');
+          anchor.href = url;
+          anchor.download = filename || 'download';
+          document.body.appendChild(anchor);
+          anchor.click();
+          setTimeout(() => {
+            URL.revokeObjectURL(url);
+            anchor.remove();
+          }, 0);
+        }
+
+        function base64ToBlob(base64, mimeType = 'application/octet-stream') {
+          const cleaned = typeof base64 === 'string' ? base64.replace(/\s/g, '') : '';
+          if (!cleaned) {
+            return new Blob([], { type: mimeType });
+          }
+          const byteCharacters = atob(cleaned);
+          const byteNumbers = new Array(byteCharacters.length);
+          for (let i = 0; i < byteCharacters.length; i += 1) {
+            byteNumbers[i] = byteCharacters.charCodeAt(i);
+          }
+          const byteArray = new Uint8Array(byteNumbers);
+          return new Blob([byteArray], { type: mimeType });
         }
 
         function resolveMoodScore(label) {


### PR DESCRIPTION
## Summary
- add CSV and PDF export endpoints that respect task filters and permissions while logging activity
- build PDF summaries with status metrics and mood counts via Apps Script HTML-to-PDF
- wire analytics tab with report export UI, download helpers, and toast feedback for success/failure

## Testing
- not run (Apps Script environment not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cab097a7dc832fa03ce19936bfba68