### PR TITLE
Phase 8: Task dependencies & comments

### DIFF
--- a/index.html
+++ b/index.html
@@ -587,6 +587,122 @@
           </section>
         </div>
       </section>
+      <div
+        id="taskDetailModal"
+        class="fixed inset-0 z-50 hidden items-end justify-center bg-slate-950/60 px-4 py-6 backdrop-blur-sm sm:items-center"
+        role="dialog"
+        aria-modal="true"
+        aria-hidden="true"
+      >
+        <div
+          id="taskDetailPanel"
+          class="relative w-full max-w-3xl overflow-hidden rounded-3xl border border-white/10 bg-slate-950/95 shadow-2xl outline-none"
+          tabindex="-1"
+        >
+          <button
+            id="taskDetailClose"
+            type="button"
+            class="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full border border-white/10 bg-white/5 text-slate-200 transition hover:bg-white/10 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white/50"
+            aria-label="Close task details"
+          >
+            ✕
+          </button>
+          <div class="space-y-6 p-6 sm:p-8">
+            <header class="flex flex-col gap-6 sm:flex-row sm:items-start sm:justify-between">
+              <div class="space-y-4">
+                <div class="flex flex-wrap items-center gap-3">
+                  <span
+                    id="taskDetailStatus"
+                    class="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white"
+                  >
+                    Status
+                  </span>
+                  <span id="taskDetailId" class="text-xs text-slate-500">—</span>
+                </div>
+                <h3 id="taskDetailTitle" class="text-2xl font-semibold leading-tight text-white">
+                  Task title
+                </h3>
+              </div>
+              <dl class="grid gap-4 text-xs text-slate-400 sm:text-right sm:text-sm">
+                <div>
+                  <dt class="font-medium uppercase tracking-wide text-[0.65rem] text-slate-400">Assignee</dt>
+                  <dd id="taskDetailAssignee" class="mt-1 text-sm text-white">—</dd>
+                </div>
+                <div>
+                  <dt class="font-medium uppercase tracking-wide text-[0.65rem] text-slate-400">Due</dt>
+                  <dd id="taskDetailDue" class="mt-1 text-sm text-white/80">—</dd>
+                </div>
+                <div>
+                  <dt class="font-medium uppercase tracking-wide text-[0.65rem] text-slate-400">Parent Task</dt>
+                  <dd id="taskDetailParent" class="mt-1 text-sm text-white/80">None</dd>
+                </div>
+              </dl>
+            </header>
+            <div
+              id="taskDetailNotes"
+              class="hidden whitespace-pre-wrap rounded-2xl border border-white/10 bg-slate-900/40 p-5 text-sm leading-relaxed text-slate-200"
+            ></div>
+            <section class="rounded-2xl border border-white/10 bg-slate-900/40 p-5">
+              <label class="flex flex-col gap-2 text-sm text-slate-200">
+                <span class="font-semibold text-white">Dependency</span>
+                <select
+                  id="taskDependencySelect"
+                  class="rounded-xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-aura-primary"
+                >
+                  <option value="">No dependency</option>
+                </select>
+                <span id="taskDependencyHint" class="text-xs text-slate-500">
+                  Select a task that must finish before this one progresses.
+                </span>
+              </label>
+            </section>
+            <section class="space-y-4">
+              <div class="flex items-center justify-between gap-3">
+                <h4 class="text-lg font-semibold text-white">Comments</h4>
+              </div>
+              <div
+                id="taskCommentsLoading"
+                class="hidden rounded-2xl border border-dashed border-white/10 bg-slate-900/40 p-4 text-sm text-slate-400"
+              >
+                Loading comments&hellip;
+              </div>
+              <div
+                id="taskCommentsError"
+                class="hidden rounded-2xl border border-rose-500/30 bg-rose-500/10 p-4 text-sm text-rose-100"
+              ></div>
+              <ul id="taskCommentsList" class="space-y-4"></ul>
+              <div
+                id="taskCommentsEmpty"
+                class="hidden rounded-2xl border border-dashed border-white/10 bg-slate-900/40 p-4 text-sm text-slate-400"
+              >
+                No comments yet. Start the discussion below.
+              </div>
+              <form id="taskCommentForm" class="space-y-3">
+                <label class="grid gap-2 text-sm text-slate-200" for="taskCommentInput">
+                  <span class="font-medium text-white">Add a comment</span>
+                  <textarea
+                    id="taskCommentInput"
+                    rows="3"
+                    class="min-h-[110px] rounded-xl border border-white/10 bg-slate-950/70 px-4 py-3 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-aura-primary"
+                    placeholder="Share updates, blockers, or context."
+                    required
+                  ></textarea>
+                </label>
+                <div class="flex items-center justify-between gap-3">
+                  <p class="text-xs text-slate-500">Markdown not supported yet — line breaks are preserved.</p>
+                  <button
+                    id="taskCommentSubmit"
+                    type="submit"
+                    class="inline-flex items-center justify-center rounded-full bg-aura-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-aura-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-aura-primary"
+                  >
+                    Post comment
+                  </button>
+                </div>
+              </form>
+            </section>
+          </div>
+        </div>
+      </div>
     </main>
 
     <script>
@@ -677,9 +793,25 @@
           isLoading: false,
           lastUpdated: null,
         };
+        const taskDetailState = {
+          isOpen: false,
+          taskId: '',
+          currentDependency: '',
+          dependencyUpdating: false,
+          comments: [],
+          commentsLoading: false,
+          commentsError: '',
+        };
         const elements = {
           analytics: {},
           focus: {},
+          kanbanBoard: null,
+          kanbanLoading: null,
+          kanbanEmpty: null,
+          kanbanColumns: {},
+          kanbanLists: {},
+          kanbanCounts: {},
+          taskDetail: {},
         };
 
         const tabs = ['dashboard', 'kanban', 'analytics', 'focus', 'admin'];
@@ -769,7 +901,47 @@
           elements.focus.historyList = document.getElementById('focusHistoryList');
           elements.focus.historyEmpty = document.getElementById('focusHistoryEmpty');
           elements.focus.clearHistoryButton = document.getElementById('focusClearHistoryButton');
-
+          elements.kanbanBoard = document.getElementById('kanbanBoard');
+          elements.kanbanLoading = document.getElementById('kanbanLoading');
+          elements.kanbanEmpty = document.getElementById('kanbanEmpty');
+          elements.kanbanColumns = {};
+          elements.kanbanLists = {};
+          elements.kanbanCounts = {};
+          if (elements.kanbanBoard) {
+            const columns = elements.kanbanBoard.querySelectorAll('[data-kanban-column]');
+            columns.forEach((column) => {
+              const status = column.getAttribute('data-kanban-column');
+              if (!status) return;
+              elements.kanbanColumns[status] = column;
+              const list = column.querySelector('[data-kanban-list]');
+              const count = column.querySelector('[data-kanban-count]');
+              if (list) {
+                elements.kanbanLists[status] = list;
+              }
+              if (count) {
+                elements.kanbanCounts[status] = count;
+              }
+            });
+          }
+          elements.taskDetail.modal = document.getElementById('taskDetailModal');
+          elements.taskDetail.panel = document.getElementById('taskDetailPanel');
+          elements.taskDetail.closeButton = document.getElementById('taskDetailClose');
+          elements.taskDetail.statusBadge = document.getElementById('taskDetailStatus');
+          elements.taskDetail.idLabel = document.getElementById('taskDetailId');
+          elements.taskDetail.title = document.getElementById('taskDetailTitle');
+          elements.taskDetail.assignee = document.getElementById('taskDetailAssignee');
+          elements.taskDetail.due = document.getElementById('taskDetailDue');
+          elements.taskDetail.parent = document.getElementById('taskDetailParent');
+          elements.taskDetail.notes = document.getElementById('taskDetailNotes');
+          elements.taskDetail.dependencySelect = document.getElementById('taskDependencySelect');
+          elements.taskDetail.dependencyHint = document.getElementById('taskDependencyHint');
+          elements.taskDetail.commentsList = document.getElementById('taskCommentsList');
+          elements.taskDetail.commentsEmpty = document.getElementById('taskCommentsEmpty');
+          elements.taskDetail.commentsLoader = document.getElementById('taskCommentsLoading');
+          elements.taskDetail.commentsError = document.getElementById('taskCommentsError');
+          elements.taskDetail.commentForm = document.getElementById('taskCommentForm');
+          elements.taskDetail.commentInput = document.getElementById('taskCommentInput');
+          elements.taskDetail.commentSubmit = document.getElementById('taskCommentSubmit');
         }
 
         function enhanceTabButtons() {
@@ -853,6 +1025,19 @@
           if (elements.focus.clearHistoryButton) {
             elements.focus.clearHistoryButton.addEventListener('click', clearFocusHistory);
           }
+          if (elements.taskDetail.closeButton) {
+            elements.taskDetail.closeButton.addEventListener('click', closeTaskDetail);
+          }
+          if (elements.taskDetail.modal) {
+            elements.taskDetail.modal.addEventListener('click', handleTaskDetailOverlayClick);
+          }
+          if (elements.taskDetail.commentForm) {
+            elements.taskDetail.commentForm.addEventListener('submit', handleTaskCommentSubmit);
+          }
+          if (elements.taskDetail.dependencySelect) {
+            elements.taskDetail.dependencySelect.addEventListener('change', handleTaskDependencyChange);
+          }
+          document.addEventListener('keydown', handleTaskDetailKeydown);
         }
 
         async function handleLoginSubmit(event) {
@@ -956,6 +1141,9 @@
           if (elements.appView) {
             elements.appView.classList.toggle('hidden', !isAuthenticated);
           }
+          if (!isAuthenticated && taskDetailState.isOpen) {
+            closeTaskDetail();
+          }
           if (elements.userBadge) {
             elements.userBadge.textContent = isAuthenticated ? state.user.Email : 'Not authenticated';
           }
@@ -1030,6 +1218,12 @@
           if (elements.analytics.refreshButton && !silent) {
             setButtonLoading(elements.analytics.refreshButton, true);
           }
+          if (elements.kanbanLoading) {
+            elements.kanbanLoading.classList.remove('hidden');
+          }
+          if (elements.kanbanEmpty) {
+            elements.kanbanEmpty.classList.add('hidden');
+          }
           try {
             const [tasks, moods] = await Promise.all([
               server.listTasks(state.token, {}),
@@ -1041,14 +1235,19 @@
             updateAnalyticsTimestamp();
             populateFocusTaskSelect();
             renderAnalyticsCharts();
+            renderKanbanBoard();
           } catch (err) {
             console.error('Failed to refresh workspace data:', err);
             showToast(err && err.message ? err.message : 'Unable to refresh analytics.', 'error');
             renderAnalyticsCharts();
+            renderKanbanBoard();
           } finally {
             analyticsState.isLoading = false;
             if (elements.analytics.refreshButton && !silent) {
               setButtonLoading(elements.analytics.refreshButton, false);
+            }
+            if (elements.kanbanLoading) {
+              elements.kanbanLoading.classList.add('hidden');
             }
           }
         }
@@ -1318,6 +1517,129 @@
             chart.destroy();
           }
           state.charts[key] = null;
+        }
+
+        function renderKanbanBoard() {
+          const board = elements.kanbanBoard;
+          if (!board) {
+            return;
+          }
+          const lists = elements.kanbanLists || {};
+          const counts = elements.kanbanCounts || {};
+          if (elements.kanbanLoading) {
+            elements.kanbanLoading.classList.add('hidden');
+          }
+          Object.keys(lists).forEach((status) => {
+            const list = lists[status];
+            if (list) {
+              list.innerHTML = '';
+            }
+          });
+          Object.keys(counts).forEach((status) => {
+            const node = counts[status];
+            if (node) {
+              node.textContent = '0';
+            }
+          });
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks.slice() : [];
+          if (!tasks.length) {
+            if (elements.kanbanEmpty) {
+              elements.kanbanEmpty.classList.remove('hidden');
+            }
+            if (taskDetailState.isOpen) {
+              renderTaskDetail();
+            }
+            return;
+          }
+          if (elements.kanbanEmpty) {
+            elements.kanbanEmpty.classList.add('hidden');
+          }
+          const fallbackList = elements.kanbanLists['Planned'] || null;
+          tasks.sort((a, b) => {
+            const orderA = STATUS_ORDER[a && a.Status] ?? 99;
+            const orderB = STATUS_ORDER[b && b.Status] ?? 99;
+            if (orderA !== orderB) {
+              return orderA - orderB;
+            }
+            const updatedA = Date.parse((a && (a.UpdatedAt || a.Timestamp)) || '') || 0;
+            const updatedB = Date.parse((b && (b.UpdatedAt || b.Timestamp)) || '') || 0;
+            if (updatedA !== updatedB) {
+              return updatedB - updatedA;
+            }
+            return (a && a.Name ? a.Name : '').localeCompare(b && b.Name ? b.Name : '');
+          });
+          tasks.forEach((task) => {
+            if (!task) {
+              return;
+            }
+            const statusKey = elements.kanbanLists[task.Status] ? task.Status : 'Planned';
+            const targetList = elements.kanbanLists[statusKey] || fallbackList;
+            if (!targetList) {
+              return;
+            }
+            const card = createKanbanTaskCard(task);
+            targetList.appendChild(card);
+            const counter = elements.kanbanCounts[statusKey];
+            if (counter) {
+              const currentValue = Number(counter.textContent) || 0;
+              counter.textContent = String(currentValue + 1);
+            }
+          });
+          if (taskDetailState.isOpen) {
+            renderTaskDetail();
+          }
+        }
+
+        function createKanbanTaskCard(task) {
+          const card = document.createElement('article');
+          card.className =
+            'group cursor-pointer rounded-2xl border border-white/10 bg-slate-950/50 p-4 transition hover:border-white/30 focus-within:border-white/40 focus:outline-none';
+          card.setAttribute('role', 'listitem');
+          card.dataset.taskId = task.TaskID;
+          card.tabIndex = 0;
+          const categoryLabel = task.Category ? task.Category : 'General';
+          const metaBadges = [];
+          if (task.DueAt) {
+            metaBadges.push(
+              `<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-slate-300">Due ${escapeHtml(formatShortDate(task.DueAt))}</span>`
+            );
+          }
+          if (task.Assignee) {
+            metaBadges.push(
+              `<span class="rounded-full bg-white/5 px-2 py-0.5 text-xs text-slate-300">${escapeHtml(task.Assignee)}</span>`
+            );
+          }
+          if (task.DependsOn) {
+            const dependencyName = getTaskNameById(task.DependsOn) || task.DependsOn;
+            metaBadges.push(
+              `<span class="rounded-full bg-aura-primary/10 px-2 py-0.5 text-xs text-aura-primary">Depends on ${escapeHtml(
+                dependencyName
+              )}</span>`
+            );
+          }
+          const badgesHtml = metaBadges.length
+            ? `<div class="mt-3 flex flex-wrap gap-2">${metaBadges.join('')}</div>`
+            : '';
+          card.innerHTML = `
+            <div class="flex items-start justify-between gap-3">
+              <div>
+                <p class="text-sm font-semibold text-white">${escapeHtml(task.Name || task.TaskID)}</p>
+                <p class="mt-1 text-xs text-slate-400">${escapeHtml(categoryLabel)}</p>
+              </div>
+              <span class="rounded-full bg-white/5 px-2 py-0.5 text-[0.65rem] uppercase tracking-wide text-slate-300">${escapeHtml(
+                task.Status || 'Planned'
+              )}</span>
+            </div>
+            ${badgesHtml}
+          `;
+          card.addEventListener('click', () => openTaskDetail(task.TaskID));
+          card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              openTaskDetail(task.TaskID);
+            }
+          });
+          return card;
         }
 
         function populateFocusTaskSelect() {
@@ -1668,7 +1990,421 @@
           updateFocusStatus('ready');
           updateFocusControls();
           updateFocusHistoryUi();
+          renderKanbanBoard();
+          if (taskDetailState.isOpen) {
+            closeTaskDetail();
+          }
         }
+
+        function openTaskDetail(taskId) {
+          const task = findTaskById(taskId);
+          if (!task) {
+            showToast('Task not found.', 'error');
+            return;
+          }
+          taskDetailState.isOpen = true;
+          taskDetailState.taskId = task.TaskID;
+          taskDetailState.currentDependency = task.DependsOn || '';
+          taskDetailState.dependencyUpdating = false;
+          taskDetailState.comments = [];
+          taskDetailState.commentsLoading = false;
+          taskDetailState.commentsError = '';
+          if (elements.taskDetail.commentInput) {
+            elements.taskDetail.commentInput.value = '';
+          }
+          renderTaskDetail();
+          renderTaskComments();
+          if (elements.taskDetail.panel) {
+            window.setTimeout(() => {
+              try {
+                elements.taskDetail.panel.focus({ preventScroll: true });
+              } catch (err) {
+                elements.taskDetail.panel.focus();
+              }
+            }, 0);
+          }
+          if (state.token) {
+            loadTaskComments(task.TaskID);
+          }
+        }
+
+        function closeTaskDetail() {
+          taskDetailState.isOpen = false;
+          taskDetailState.taskId = '';
+          taskDetailState.currentDependency = '';
+          taskDetailState.dependencyUpdating = false;
+          taskDetailState.comments = [];
+          taskDetailState.commentsLoading = false;
+          taskDetailState.commentsError = '';
+          if (elements.taskDetail.modal) {
+            elements.taskDetail.modal.classList.add('hidden');
+            elements.taskDetail.modal.setAttribute('aria-hidden', 'true');
+          }
+        }
+
+        function renderTaskDetail() {
+          const modal = elements.taskDetail.modal;
+          if (!modal) {
+            return;
+          }
+          if (!taskDetailState.isOpen) {
+            modal.classList.add('hidden');
+            modal.setAttribute('aria-hidden', 'true');
+            return;
+          }
+          const task = findTaskById(taskDetailState.taskId);
+          if (!task) {
+            showToast('Task is no longer available.', 'error');
+            closeTaskDetail();
+            return;
+          }
+          modal.classList.remove('hidden');
+          modal.setAttribute('aria-hidden', 'false');
+          if (elements.taskDetail.statusBadge) {
+            elements.taskDetail.statusBadge.textContent = task.Status || 'Planned';
+            applyStatusBadgeStyle(elements.taskDetail.statusBadge, task.Status);
+          }
+          if (elements.taskDetail.idLabel) {
+            elements.taskDetail.idLabel.textContent = task.TaskID;
+          }
+          if (elements.taskDetail.title) {
+            elements.taskDetail.title.textContent = task.Name || task.TaskID;
+          }
+          if (elements.taskDetail.assignee) {
+            elements.taskDetail.assignee.textContent = task.Assignee ? task.Assignee : 'Unassigned';
+          }
+          if (elements.taskDetail.due) {
+            elements.taskDetail.due.textContent = task.DueAt ? formatDetailDate(task.DueAt) : 'No due date';
+          }
+          if (elements.taskDetail.parent) {
+            if (task.ParentTaskID) {
+              const parentTask = findTaskById(task.ParentTaskID);
+              elements.taskDetail.parent.textContent = parentTask ? parentTask.Name || parentTask.TaskID : task.ParentTaskID;
+            } else {
+              elements.taskDetail.parent.textContent = 'None';
+            }
+          }
+          if (elements.taskDetail.notes) {
+            const note = (task.Notes || '').trim();
+            if (note) {
+              elements.taskDetail.notes.classList.remove('hidden');
+              elements.taskDetail.notes.textContent = note;
+            } else {
+              elements.taskDetail.notes.classList.add('hidden');
+              elements.taskDetail.notes.textContent = '';
+            }
+          }
+          populateDependencySelect(task);
+        }
+
+        function populateDependencySelect(task) {
+          const select = elements.taskDetail.dependencySelect;
+          if (!select) {
+            return;
+          }
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks.slice() : [];
+          select.innerHTML = '';
+          const defaultOption = document.createElement('option');
+          defaultOption.value = '';
+          defaultOption.textContent = 'No dependency';
+          select.appendChild(defaultOption);
+          tasks
+            .filter((item) => item && item.TaskID && item.TaskID !== task.TaskID)
+            .sort((a, b) => (a.Name || '').localeCompare(b.Name || ''))
+            .forEach((item) => {
+              const option = document.createElement('option');
+              option.value = item.TaskID;
+              option.textContent = item.Name || item.TaskID;
+              select.appendChild(option);
+            });
+          const current = task.DependsOn || '';
+          const hasOption = Array.from(select.options).some((option) => option.value === current);
+          select.value = hasOption ? current : '';
+          taskDetailState.currentDependency = select.value;
+          if (taskDetailState.dependencyUpdating) {
+            select.disabled = true;
+            select.classList.add('opacity-60');
+          } else {
+            select.disabled = false;
+            select.classList.remove('opacity-60');
+          }
+          updateDependencyHint();
+        }
+
+        function updateDependencyHint() {
+          const hint = elements.taskDetail.dependencyHint;
+          const select = elements.taskDetail.dependencySelect;
+          if (!hint || !select) {
+            return;
+          }
+          const value = select.value || '';
+          if (value) {
+            const dependencyTask = findTaskById(value);
+            const label = dependencyTask ? dependencyTask.Name || dependencyTask.TaskID : value;
+            hint.textContent = `This task waits on ${label}.`;
+          } else {
+            hint.textContent = 'Select a task that must finish before this one progresses.';
+          }
+        }
+
+        async function handleTaskDependencyChange(event) {
+          const select = event.target;
+          if (!taskDetailState.isOpen) {
+            return;
+          }
+          if (!state.token || !taskDetailState.taskId) {
+            select.value = taskDetailState.currentDependency || '';
+            updateDependencyHint();
+            showToast('Sign in to update dependencies.', 'error');
+            return;
+          }
+          const nextValue = select.value || '';
+          if (nextValue === (taskDetailState.currentDependency || '')) {
+            updateDependencyHint();
+            return;
+          }
+          select.disabled = true;
+          select.classList.add('opacity-60');
+          taskDetailState.dependencyUpdating = true;
+          try {
+            await server.updateTask(state.token, taskDetailState.taskId, { DependsOn: nextValue });
+            updateLocalTask(taskDetailState.taskId, { DependsOn: nextValue });
+            taskDetailState.currentDependency = nextValue;
+            showToast(nextValue ? 'Dependency updated.' : 'Dependency cleared.', 'success');
+            renderKanbanBoard();
+          } catch (err) {
+            console.error('Failed to update dependency:', err);
+            select.value = taskDetailState.currentDependency || '';
+            showToast(err && err.message ? err.message : 'Unable to update dependency.', 'error');
+          } finally {
+            taskDetailState.dependencyUpdating = false;
+            select.disabled = false;
+            select.classList.remove('opacity-60');
+            renderTaskDetail();
+          }
+        }
+
+        async function handleTaskCommentSubmit(event) {
+          event.preventDefault();
+          if (!taskDetailState.isOpen) {
+            return;
+          }
+          if (!state.token) {
+            showToast('Sign in to comment.', 'error');
+            return;
+          }
+          const input = elements.taskDetail.commentInput;
+          const button = elements.taskDetail.commentSubmit;
+          if (!input || !button) {
+            return;
+          }
+          const text = input.value.trim();
+          if (!text) {
+            showToast('Enter a comment before posting.', 'error');
+            return;
+          }
+          button.disabled = true;
+          button.classList.add('opacity-60');
+          try {
+            await server.addComment(state.token, taskDetailState.taskId, text);
+            input.value = '';
+            await loadTaskComments(taskDetailState.taskId);
+            showToast('Comment posted.', 'success');
+          } catch (err) {
+            console.error('Failed to add comment:', err);
+            showToast(err && err.message ? err.message : 'Unable to add comment.', 'error');
+          } finally {
+            button.disabled = false;
+            button.classList.remove('opacity-60');
+          }
+        }
+
+        function handleTaskDetailOverlayClick(event) {
+          if (!elements.taskDetail.modal) {
+            return;
+          }
+          if (event.target === elements.taskDetail.modal) {
+            closeTaskDetail();
+          }
+        }
+
+        function handleTaskDetailKeydown(event) {
+          if (event.key === 'Escape' && taskDetailState.isOpen) {
+            closeTaskDetail();
+          }
+        }
+
+        async function loadTaskComments(taskId) {
+          taskDetailState.commentsLoading = true;
+          taskDetailState.commentsError = '';
+          renderTaskComments();
+          if (!state.token) {
+            taskDetailState.commentsLoading = false;
+            renderTaskComments();
+            return;
+          }
+          try {
+            const comments = await server.listComments(state.token, taskId);
+            if (taskDetailState.taskId === taskId) {
+              taskDetailState.comments = Array.isArray(comments) ? comments : [];
+            }
+          } catch (err) {
+            console.error('Failed to load comments:', err);
+            if (taskDetailState.taskId === taskId) {
+              taskDetailState.comments = [];
+              taskDetailState.commentsError = err && err.message ? err.message : 'Unable to load comments.';
+            }
+          } finally {
+            if (taskDetailState.taskId === taskId) {
+              taskDetailState.commentsLoading = false;
+              renderTaskComments();
+            }
+          }
+        }
+
+        function renderTaskComments() {
+          const list = elements.taskDetail.commentsList;
+          const empty = elements.taskDetail.commentsEmpty;
+          const loader = elements.taskDetail.commentsLoader;
+          const errorNode = elements.taskDetail.commentsError;
+          if (!list) {
+            return;
+          }
+          if (!taskDetailState.isOpen) {
+            list.innerHTML = '';
+            if (empty) empty.classList.add('hidden');
+            if (loader) loader.classList.add('hidden');
+            if (errorNode) errorNode.classList.add('hidden');
+            return;
+          }
+          if (loader) {
+            loader.classList.toggle('hidden', !taskDetailState.commentsLoading);
+          }
+          if (errorNode) {
+            if (taskDetailState.commentsError) {
+              errorNode.textContent = taskDetailState.commentsError;
+              errorNode.classList.remove('hidden');
+            } else {
+              errorNode.textContent = '';
+              errorNode.classList.add('hidden');
+            }
+          }
+          if (taskDetailState.commentsLoading) {
+            list.innerHTML = '';
+            if (empty) {
+              empty.classList.add('hidden');
+            }
+            return;
+          }
+          const comments = Array.isArray(taskDetailState.comments) ? taskDetailState.comments : [];
+          if (!comments.length) {
+            list.innerHTML = '';
+            if (empty && !taskDetailState.commentsError) {
+              empty.classList.remove('hidden');
+            } else if (empty) {
+              empty.classList.add('hidden');
+            }
+            return;
+          }
+          if (empty) {
+            empty.classList.add('hidden');
+          }
+          list.innerHTML = comments
+            .map((comment) => {
+              const author = comment.UserEmail || 'Unknown';
+              const timestamp = formatCommentTimestamp(comment.CreatedAt);
+              const body = escapeHtml(comment.Text || '').replace(/\n/g, '<br />');
+              return `<li class="rounded-2xl border border-white/10 bg-slate-950/50 p-4">
+                <div class="flex flex-wrap items-center justify-between gap-2 text-xs text-slate-400">
+                  <span class="font-semibold text-slate-200">${escapeHtml(author)}</span>
+                  <span>${escapeHtml(timestamp)}</span>
+                </div>
+                <div class="mt-3 text-sm leading-relaxed text-slate-200">${body}</div>
+              </li>`;
+            })
+            .join('');
+        }
+
+        function updateLocalTask(taskId, updates) {
+          if (!taskId || !updates) {
+            return;
+          }
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
+          const index = tasks.findIndex((task) => task && task.TaskID === taskId);
+          if (index === -1) {
+            return;
+          }
+          const current = tasks[index] || {};
+          tasks[index] = Object.assign({}, current, updates);
+          state.data.tasks = tasks;
+        }
+
+        function findTaskById(taskId) {
+          if (!taskId) {
+            return null;
+          }
+          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
+          for (let i = 0; i < tasks.length; i += 1) {
+            if (tasks[i] && tasks[i].TaskID === taskId) {
+              return tasks[i];
+            }
+          }
+          return null;
+        }
+
+        function applyStatusBadgeStyle(element, status) {
+          if (!element) {
+            return;
+          }
+          const palette = {
+            'In-Progress': 'border-sky-400/30 bg-sky-500/20 text-sky-100',
+            Planned: 'border-white/15 bg-white/10 text-slate-100',
+            Completed: 'border-emerald-400/30 bg-emerald-500/20 text-emerald-100',
+            Shifted: 'border-amber-400/30 bg-amber-500/20 text-amber-100',
+            Cancelled: 'border-rose-400/30 bg-rose-500/20 text-rose-100',
+          };
+          const base = 'rounded-full border px-3 py-1 text-xs font-semibold uppercase tracking-wide ';
+          element.className = base + (palette[status] || palette.Planned);
+        }
+
+        function formatDetailDate(value) {
+          if (!value) return '';
+          const date = new Date(value);
+          if (Number.isNaN(date.getTime())) {
+            return String(value);
+          }
+          return date.toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+        }
+
+        function formatShortDate(value) {
+          if (!value) return '';
+          const date = new Date(value);
+          if (Number.isNaN(date.getTime())) {
+            return String(value);
+          }
+          return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+        }
+
+        function formatCommentTimestamp(value) {
+          if (!value) return '';
+          const date = new Date(value);
+          if (Number.isNaN(date.getTime())) {
+            return String(value);
+          }
+          return date.toLocaleString(undefined, {
+            month: 'short',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+          });
+        }
+
 
         function toggleEmptyState(element, shouldShow) {
           if (!element) return;
@@ -1710,10 +2446,8 @@
         }
 
         function getTaskNameById(taskId) {
-          if (!taskId) return '';
-          const tasks = Array.isArray(state.data.tasks) ? state.data.tasks : [];
-          const match = tasks.find((task) => task.TaskID === taskId);
-          return match ? match.Name || match.TaskID : '';
+          const task = findTaskById(taskId);
+          return task ? task.Name || task.TaskID : '';
         }
 
         function formatHistoryTimestamp(date) {


### PR DESCRIPTION
## Summary
- extend the Tasks sheet with a DependsOn column and enforce dependency validation during task create/update
- introduce a Comments sheet plus addComment/listComments APIs and clean up records when tasks are deleted
- enhance the frontend with a kanban task renderer, task detail modal, dependency selector, and in-app commenting powered by the new endpoints

## Testing
- not run (Apps Script runtime not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cab11de8e0832faf9bb78edc715119